### PR TITLE
Fix Build

### DIFF
--- a/core/src/main/java/de/muenchen/rbs/kitafinderdatenservice/repository/OutboxEventRepository.java
+++ b/core/src/main/java/de/muenchen/rbs/kitafinderdatenservice/repository/OutboxEventRepository.java
@@ -13,7 +13,7 @@ import org.springframework.data.repository.PagingAndSortingRepository;
 import de.muenchen.rbs.kitafinderdatenservice.domain.events.OutboxState;
 import de.muenchen.rbs.kitafinderdatenservice.domain.events.Outboxevent;
 
-public interface OutboxeventRepository
+public interface OutboxEventRepository
 		extends PagingAndSortingRepository<Outboxevent, UUID>, CrudRepository<Outboxevent, UUID> {
 
 	List<Outboxevent> findByAggregateId(Long aggregateId);

--- a/core/src/main/java/de/muenchen/rbs/kitafinderdatenservice/service/OutboxEventHandlerDelegator.java
+++ b/core/src/main/java/de/muenchen/rbs/kitafinderdatenservice/service/OutboxEventHandlerDelegator.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import de.muenchen.rbs.kitafinderdatenservice.domain.events.OutboxState;
 import de.muenchen.rbs.kitafinderdatenservice.domain.events.Outboxevent;
-import de.muenchen.rbs.kitafinderdatenservice.repository.OutboxeventRepository;
+import de.muenchen.rbs.kitafinderdatenservice.repository.OutboxEventRepository;
 import io.micrometer.core.annotation.Timed;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class OutboxEventHandlerDelegator {
 
-	private final OutboxeventRepository outboxRepo;
+	private final OutboxEventRepository outboxRepo;
 	private final PluginRegistry<EventHandlerDelegate, Outboxevent> plugins;
 	private final int maxRetryCount;
 	private final Duration backoffDurationBase;
@@ -46,10 +46,10 @@ public class OutboxEventHandlerDelegator {
 	 * @param maxRetryCount       max retry count
 	 * @param backoffDurationBase Backoff Duration Basis (minimale Backoff Zeit)
 	 */
-	public OutboxEventHandlerDelegator(OutboxeventRepository outboxRepo,
-			PluginRegistry<EventHandlerDelegate, Outboxevent> plugins, MeterRegistry meterRegistry,
-			@Value("${app.outbox.retry.max-retries:0}") int maxRetryCount,
-			@Value("${app.outbox.retry.backoff-duration-base:PT30S}") Duration backoffDurationBase) {
+	public OutboxEventHandlerDelegator(OutboxEventRepository outboxRepo,
+									   PluginRegistry<EventHandlerDelegate, Outboxevent> plugins, MeterRegistry meterRegistry,
+									   @Value("${app.outbox.retry.max-retries:0}") int maxRetryCount,
+									   @Value("${app.outbox.retry.backoff-duration-base:PT30S}") Duration backoffDurationBase) {
 		this.outboxRepo = outboxRepo;
 		this.plugins = plugins;
 		this.maxRetryCount = maxRetryCount;

--- a/core/src/main/java/de/muenchen/rbs/kitafinderdatenservice/service/OutboxEventHandlerDelegator.java
+++ b/core/src/main/java/de/muenchen/rbs/kitafinderdatenservice/service/OutboxEventHandlerDelegator.java
@@ -18,7 +18,7 @@ import io.micrometer.core.instrument.MeterRegistry;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Service, der {@link OutboxEvent}s konsumiert, an entsprechende Handler
+ * Service, der {@link Outboxevent}s konsumiert, an entsprechende Handler
  * weitergibt und den Status der Abarbeitung setzt.
  * 
  * @author michael.prankl
@@ -64,7 +64,7 @@ public class OutboxEventHandlerDelegator {
 	 * Konsumiert das übergebene Event und delegiert die eigentliche Arbeit an ein
 	 * passendes Delegates.
 	 * 
-	 * @param event ein {@link OutboxEvent}
+	 * @param event ein {@link Outboxevent}
 	 */
 	@Transactional
 	@Timed(value = "app_outbox_events_consume_time", description = "Verarbeitungszeit für die Verarbeitung eines Outbox Events")

--- a/core/src/main/java/de/muenchen/rbs/kitafinderdatenservice/service/OutboxeventService.java
+++ b/core/src/main/java/de/muenchen/rbs/kitafinderdatenservice/service/OutboxeventService.java
@@ -11,14 +11,14 @@ import de.muenchen.rbs.kitafinderdatenservice.domain.Kind;
 import de.muenchen.rbs.kitafinderdatenservice.domain.Vertrag;
 import de.muenchen.rbs.kitafinderdatenservice.domain.events.EventType;
 import de.muenchen.rbs.kitafinderdatenservice.domain.events.Outboxevent;
-import de.muenchen.rbs.kitafinderdatenservice.repository.OutboxeventRepository;
+import de.muenchen.rbs.kitafinderdatenservice.repository.OutboxEventRepository;
 import jakarta.validation.Valid;
 
 @Service
 public class OutboxeventService {
 
 	@Autowired
-	private OutboxeventRepository repository;
+	private OutboxEventRepository repository;
 
 	@Autowired
 	private ObjectMapper mapper;

--- a/core/src/main/java/de/muenchen/rbs/kitafinderdatenservice/service/PollingOutboxEventTask.java
+++ b/core/src/main/java/de/muenchen/rbs/kitafinderdatenservice/service/PollingOutboxEventTask.java
@@ -14,7 +14,7 @@ import org.springframework.util.StopWatch;
 
 import de.muenchen.rbs.kitafinderdatenservice.domain.events.OutboxState;
 import de.muenchen.rbs.kitafinderdatenservice.domain.events.Outboxevent;
-import de.muenchen.rbs.kitafinderdatenservice.repository.OutboxeventRepository;
+import de.muenchen.rbs.kitafinderdatenservice.repository.OutboxEventRepository;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -34,11 +34,11 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 public class PollingOutboxEventTask {
 
 	private int maxBatchSize;
-	private final OutboxeventRepository outboxRepo;
+	private final OutboxEventRepository outboxRepo;
 	private final OutboxEventHandlerDelegator outboxEventConsumer;
 
 	public PollingOutboxEventTask(@Value("${app.outbox.polling.max-batch-size:100}") int maxBatchSize,
-			OutboxeventRepository outboxRepo, OutboxEventHandlerDelegator outboxEventConsumer) {
+                                  OutboxEventRepository outboxRepo, OutboxEventHandlerDelegator outboxEventConsumer) {
 		super();
 		this.maxBatchSize = maxBatchSize;
 		this.outboxRepo = outboxRepo;


### PR DESCRIPTION
**Description**

OutboxEventRepository hatte einen anderen Filenamen als die Klasse geheisen hat. Daher kam der compile Error.
Lokal kann die IDE damit iwie umgehen wenn man die Klasse einmal gebaut hat. Daher konntest du das lokal nicht nachstellen.
Dont ask me why... 

**Reference**

Issues #XXX
